### PR TITLE
Add Linux artifact to Brim releases

### DIFF
--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -6,8 +6,11 @@ on:
       - v*brim*
 
 jobs:
-  macos:
-    runs-on: macos-10.15
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
       - run: ./brim/release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 project(Zeek C CXX)
 
 # Brim: Prefer static libraries.
-set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+if ( CMAKE_SYSTEM_NAME STREQUAL Darwin )
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+elseif ( CMAKE_SYSTEM_NAME STREQUAL Linux )
+    set(CMAKE_DL_LIBS pthread ${CMAKE_DL_LIBS})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+endif ()
 
 # When changing the minimum version here, also adapt
 # aux/zeek-aux/plugin-support/skeleton/CMakeLists.txt

--- a/brim/release
+++ b/brim/release
@@ -1,10 +1,30 @@
 #!/bin/sh -ex
 
-brew install bison openssl
+case $(uname -s) in
+    Darwin)
+        goos=darwin
+        logical_cpus=$(sysctl -n hw.logicalcpu)
+        brew install bison openssl
+        ;;
+    Linux)
+        goos=linux
+        logical_cpus=$(nproc)
+        sudo apt-get -y install bison flex libpcap-dev libssl-dev
+        ;;
+    *)
+        echo "unknown OS" >&2
+        exit 1
+        ;;
+esac
+
 git submodule update --init --recursive
 ./configure --binary-package --disable-auxtools --disable-broker-tests --disable-python --disable-zeekctl --enable-static-binpac --enable-static-broker
-sudo make -C build -j $(sysctl -n hw.logicalcpu) install/strip
+sudo make -C build/scripts -j $logical_cpus install/strip
+sudo make -C build/src -j $logical_cpus install/strip
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
-mkdir -p zeek/share/zeek && cp -R /usr/local/zeek/share/zeek/{base,policy,site} zeek/share/zeek
+mkdir -p zeek/share/zeek
+for d in base policy site; do
+    cp -R /usr/local/zeek/share/zeek/$d zeek/share/zeek
+done
 cp brim/zeek zeek
-zip -r zeek-$(git describe --dirty --tags).darwin-amd64.zip zeek
+zip -r zeek-$(git describe --dirty --tags).$goos-amd64.zip zeek


### PR DESCRIPTION
The GitHub workflow for Brim releases now creates a GitHub release with
two artifacts: zeek-TAG.darwin-amd64.zip and zeek-TAG.linux-amd64.zip.