### PR TITLE
Change format of rules output by print-types.zeek

### DIFF
--- a/brim/print-types.zeek
+++ b/brim/print-types.zeek
@@ -185,8 +185,8 @@ event zeek_init() &priority = -100
 	for ( i in paths )
 		{
 		local s = "";
-		s += "{\"match\": {\"_path\": ";
-		s += cat("\"", paths[i], "\"},");
+		s += "{\"name\":\"_path\", ";
+		s += cat("\"value\":\"", paths[i], "\",");
 		s += cat("\"descriptor\":\"", paths[i]+"_log", "\"}");
 		rules += s;
 		}


### PR DESCRIPTION
They were previously like this `{"_path": "http", "descriptor": "conn_log"}` and this PR changes them to be like this `{"name": "_path", "value": "http", "descriptor": "conn_log"}`, which is easier to validate and handle programmatically. The former representation was intended to allow matching rules on multiple fields, but that doesn't seem likely to be a necessary feature any time soon.