### PR TITLE
specify osx-min-version to configure

### DIFF
--- a/brim/release
+++ b/brim/release
@@ -18,7 +18,10 @@ case $(uname -s) in
 esac
 
 git submodule update --init --recursive
-./configure --binary-package --disable-auxtools --disable-broker-tests --disable-python --disable-zeekctl --enable-static-binpac --enable-static-broker
+./configure \
+	--binary-package --disable-auxtools --disable-broker-tests \
+	--disable-python --disable-zeekctl --enable-static-binpac \
+	--enable-static-broker --osx-min-version=10.10
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin


### PR DESCRIPTION
We've had a user report that they can't load any pcaps, and were seeing this error:
```
Detail: zeek exited with status -1: dyld: lazy symbol binding failed: Symbol not found: ____chkstk_darwin Referenced from: /Applications/Brim.app/Contents/Resources/app/zdeps/zeek/bin/zeek (which was built for Mac OS X 10.15) Expected in: /usr/lib/libSystem.B.dylib dyld: Symbol not found: ____chkstk_darwin Referenced from: /Applications/Brim.app/Contents/Resources/app/zdeps/zeek/bin/zeek (which was built for Mac OS X 10.15) Expected in: /usr/lib/libSystem.
```

So we'll build zeek specifying a minimum MacOS version. I've built an executable by hand and asked them to report back if it helps. I'm selecting 10.10 because that's the current minimum for the go & electron versions we're using at the moment.
