### PR TITLE
Add Zeek scripts for JA3 and HASSH

### DIFF
--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -13,6 +13,7 @@ jobs:
         os: [macos-10.15, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
       - run: ./brim/release
       - uses: svenstaro/upload-release-action@1.1.0
         with:

--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,15 +2,15 @@ name: Brim release
 
 on:
   push:
-    tags:
-      - v*brim*
+    branches:
+      - add-ja3-hassh
 
 jobs:
   release:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-10.15]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow

--- a/brim/add-scripts.sh
+++ b/brim/add-scripts.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+declare -a REPOS=(
+    'https://github.com/salesforce/ja3.git'
+    'https://github.com/salesforce/hassh.git'
+)
+
+for REPO in "${REPOS[@]}"; do
+    TMPDIR=$(mktemp -d)
+    ZSCRIPTS_DIR="$SCRIPT_DIR/../scripts/site"
+    SCRIPTNAME="${REPO/\.git/}"
+    SCRIPTNAME="${SCRIPTNAME/*\//}"
+    git clone "$REPO" "$TMPDIR"
+    for DIR in zeek bro scripts; do
+        if [ -d "$TMPDIR/$DIR" ]; then
+            mv "$TMPDIR/$DIR" "$ZSCRIPTS_DIR/$SCRIPTNAME"
+        fi
+    done
+
+    # This commented-out stuff below are things I came up with when I was
+    # hacking with other random Zeek scripts that were still "Bro"-ified and
+    # had to be brought current to work with the newer Zeek version we use.
+    # It's certainly our preference to get the upstream projects to
+    # Zeek-ify for the good of the community before we depend on them, but I'm
+    # leaving the dormant script code here just in case we ever want to add a
+    # script desperately enough, as this will help us either bring in the
+    # modified scripts as a one-off or to create changes we'd commit to our own
+    # forked copy of a script repo.
+    #
+    # for BRO_FILE in $(find "$ZSCRIPTS_DIR" -name \*.bro); do
+    #     mv -- "$BRO_FILE" "${BRO_FILE%.bro}.zeek"
+    # done
+    # for LOAD_SCRIPT in $(find "$ZSCRIPTS_DIR" -name __load__.zeek); do
+    #     perl -i -pe "s/\.bro$/.zeek/" "$LOAD_SCRIPT"
+    #     perl -i -pe "s/@load packages/@load site/" "$LOAD_SCRIPT"
+    # done
+    # for ZSCRIPT in $(find "$ZSCRIPTS_DIR" -name \*.zeek); do
+    #     perl -i -pe "s/bro_init\(\)/zeek_init()/" "$ZSCRIPT"
+    # done
+
+    echo "@load ./$SCRIPTNAME" >> "$ZSCRIPTS_DIR/local.zeek"
+done

--- a/scripts/site/hassh/README.md
+++ b/scripts/site/hassh/README.md
@@ -1,0 +1,94 @@
+# hassh.zeek
+[![License: BSD 3-Clause License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+
+## Features
+**hassh.zeek** by default will add these fields to your Zeek ssh.log file 
+- hasshVersion
+- hassh, hasshAlgorithms 
+- hasshServer, hasshServerAlgorithms
+- cshka (Client Host Key Algorithms), sshka (Server Host Key Algorithms)  
+- The script has been tested on Bro 2.5, 2.5.1, 2.5.5, 2.6.0, 2.6.1, 2.6.3, 3.0.0 and 3.1.2
+- Note that Zeek (formerly bro) versions < v2.6.0 had a bug which reversed the Client/server flag , see https://github.com/zeek/zeek/pull/191. The current version of the hassh.zeek script does version checking to deal with these version issues. Failure to update Zeek and not the hassh.zeek script will result in the Server and Client packets being processed incorrectly, in effect swapping around hassh with hassServer.  
+
+## Installation
+Place hassh.zeek in zeek/share/zeek/site/hassh and add this line to your local.zeek script:
+```bash
+@load ./hassh
+```
+If running Zeek >=2.5 or a Zeek product like Corelight, install by using the Zeek Package Manager with this command:
+```bash 
+zkg install hassh
+```
+
+
+## Configuration
+**hassh.zeek** by default will add these fields to your Zeek ssh.log file: ```hasshVersion, hassh, hasshAlgorithms, hasshServer and hasshServerAlgorithms, cshka, sshka.``` If you don't want some of these fields to be logged, simply comment those field lines out in each of the locations within hassh.zeek as shown in the code blocks below.
+```bash
+redef record SSH::Info += {
+    hasshVersion:  string  &log &optional;
+    hassh:         string  &log &optional;
+    hasshServer:   string  &log &optional;
+    
+    # ===> Log Client variables <=== #
+    # Comment out any fields that are not required to be logged in their raw form to ssh.log
+    #ckex:    string   &log &optional;
+    cshka:   string   &log &optional; 
+    #ceacts:  string   &log &optional; 
+    #cmacts:  string   &log &optional;
+    #ccacts:  string   &log &optional; 
+    #clcts:   string   &log &optional;
+    hasshAlgorithms:  string  &log &optional;
+    
+    # ===> Log Server variables <=== #
+    # Comment out any fields that are not required to be logged in their raw form to ssh.log
+    #skex:     string  &log &optional; 
+    sshka:    string  &log &optional; 
+    #seastc:   string  &log &optional; 
+    #smastc:   string  &log &optional; 
+    #scastc:   string  &log &optional; 
+    #slstc:    string  &log &optional;
+    hasshServerAlgorithms:  string  &log &optional;
+};
+```
+```bash
+    if ( capabilities$is_server == T ) {
+        get_hassh(c, capabilities);
+        c$ssh$hasshVersion = c$hassh$hasshVersion;
+        c$ssh$hassh  = c$hassh$hassh;
+        
+        # ===> Log Client variables <=== #
+        # Comment out any fields that are not required to be logged in their raw form to ssh.log
+        #c$ssh$ckex   = c$hassh$ckex;
+        c$ssh$cshka  = c$hassh$cshka;
+        #c$ssh$ceacts = c$hassh$ceacts;
+        #c$ssh$cmacts = c$hassh$cmacts;
+        #c$ssh$ccacts = c$hassh$ccacts;
+        #c$ssh$clcts  = c$hassh$clcts;
+        c$ssh$hasshAlgorithms = c$hassh$hasshAlgorithms;
+    }
+    if ( capabilities$is_server == F ) {
+        get_hasshServer(c, capabilities);
+        c$ssh$hasshVersion = c$hassh$hasshVersion;
+        c$ssh$hasshServer = c$hassh$hasshServer;
+        
+        # ===> Log Server variables <=== #
+        # Comment out any fields that are not required to be logged in their raw form to ssh.log
+        #c$ssh$skex   = c$hassh$skex;
+        c$ssh$sshka  = c$hassh$sshka;
+        #c$ssh$seastc = c$hassh$seastc;
+        #c$ssh$smastc = c$hassh$smastc;
+        #c$ssh$scastc = c$hassh$scastc;
+        #c$ssh$slstc  = c$hassh$clcts;
+        c$ssh$hasshServerAlgorithms = c$hassh$hasshServerAlgorithms;
+    }
+```
+
+After ammending the Zeek script, don't forget to reload Zeek. 
+```bash
+zeekctl stop
+zeekctl install
+zeekctl start
+```
+
+## Credits:
+HASSH was conceived and developed by [Ben Reardon](mailto:breardon@salesforce.com) (@benreardon) within the Detection Cloud Team at Salesforce, with inspiration and contributions from [Adel Karimi](mailto:akarimishiraz@salesforce.com) (@0x4d31) and the [JA3 crew](https://github.com/salesforce/ja3/)  crew:[John B. Althouse](mailto:jalthouse@salesforce.com)  , [Jeff Atkinson](mailto:jatkinson@salesforce.com) and [Josh Atkins](mailto:j.atkins@salesforce.com)

--- a/scripts/site/hassh/__load__.zeek
+++ b/scripts/site/hassh/__load__.zeek
@@ -1,0 +1,1 @@
+@load ./hassh.zeek

--- a/scripts/site/hassh/hassh.zeek
+++ b/scripts/site/hassh/hassh.zeek
@@ -1,0 +1,144 @@
+#                               HASSH                                #
+#             SSH Key Initiation Exchange Fingerprinting             #
+#                                                                    #
+# Script Version: v1.5 22 August 2019                                #
+# Authors: Ben Reardon (breardon@salesforce.com, @benreardon)        #
+#        : Jeff Atkinson (jatkinson@salesforce.com)                  #
+#        : John Althouse (jalthouse@salesforce.com)                  #
+# Description:  This Zeek script appends hassh data to ssh.log       #
+#               by enumerating the SSH_MSG_KEXINIT packets sent      #
+#               as clear text between the client and server as part  # 
+#               of the negotiation of an SSH connection.             #
+#                                                                    #
+# Copyright (c) 2018, salesforce.com, inc.                           #
+# All rights reserved.                                               #
+# SPDX-License-Identifier: BSD-3-Clause                              #
+# For full license text, see the LICENSE file in the repo root or    #
+# https://opensource.org/licenses/BSD-3-Clause                       #
+
+
+module SSH;
+
+export {
+    type HASSHStorage: record {
+        hasshVersion:string &log &default="1.1"; # ANY change in hassh/hasshServer composition requires Version update 
+        hassh:   string   &log &optional &default="";
+        hasshServer:   string  &log &optional &default="";
+        
+        # Client variables #
+        ckex:    string   &log &optional &default="";
+        cshka:   string   &log &optional &default="";
+        ceacts:  string   &log &optional &default="";
+        cmacts:  string   &log &optional &default="";
+        ccacts:  string   &log &optional &default="";
+        #clcts:  string   &log &optional &default=""; 
+        hasshAlgorithms:  string  &log &optional &default="";
+        
+        # Server variables #
+        skex:     string  &log &optional &default="";
+        sshka:    string  &log &optional &default="";
+        seastc:   string  &log &optional &default="";
+        smastc:   string  &log &optional &default="";
+        scastc:   string  &log &optional &default="";
+        #slstc:   string  &log &optional &default="";
+        hasshServerAlgorithms:  string  &log &optional &default="";
+    };
+}
+
+redef record connection += {
+    hassh: HASSHStorage &optional;
+};
+    
+redef record SSH::Info += {
+    hasshVersion:  string  &log &optional;
+    hassh:         string  &log &optional;
+    hasshServer:   string  &log &optional;
+    
+    # ===> Log Client variables <=== #
+    # Comment out any fields that are not required to be logged in their raw form to ssh.log
+    #ckex:    string   &log &optional;
+    cshka:   string   &log &optional; 
+    #ceacts:  string   &log &optional; 
+    #cmacts:  string   &log &optional;
+    #ccacts:  string   &log &optional; 
+    #clcts:   string   &log &optional;
+    hasshAlgorithms:  string  &log &optional;
+    
+    # ===> Log Server variables <=== #
+    # Comment out any fields that are not required to be logged in their raw form to ssh.log
+    #skex:     string  &log &optional; 
+    sshka:    string  &log &optional; 
+    #seastc:   string  &log &optional; 
+    #smastc:   string  &log &optional; 
+    #scastc:   string  &log &optional; 
+    #slstc:    string  &log &optional;
+    hasshServerAlgorithms:  string  &log &optional;
+};
+
+
+# Build Client Application fingerprint #
+function get_hassh(c:connection, capabilities: SSH::Capabilities ) {
+    c$hassh = HASSHStorage();
+    c$hassh$ckex   = join_string_vec(capabilities$kex_algorithms,",");
+    c$hassh$ceacts = join_string_vec(capabilities$encryption_algorithms$client_to_server,",");
+    c$hassh$cmacts = join_string_vec(capabilities$mac_algorithms$client_to_server,",");
+    c$hassh$ccacts = join_string_vec(capabilities$compression_algorithms$client_to_server,",");
+    c$hassh$cshka  = join_string_vec(capabilities$server_host_key_algorithms,","); # The Host key algorithm set may be useful information by itself but is not included in the hassh.
+    #c$hassh$clcts  = join_string_vec(capabilities$languages$client_to_server,","); # The Languages field may be useful information by itself but is not included in the hasshServer.
+    c$hassh$hasshAlgorithms = string_cat(c$hassh$ckex,";",c$hassh$ceacts,";",c$hassh$cmacts,";",c$hassh$ccacts); # Contatenate the four selected lists of algorithms (Key,Enc,MAC,Compression) to build the Client hash
+    c$hassh$hassh = md5_hash(c$hassh$hasshAlgorithms);
+}
+
+# Build Server Application fingerprint #
+function get_hasshServer(c:connection, capabilities: SSH::Capabilities ) {
+    c$hassh = HASSHStorage();
+    c$hassh$skex   = join_string_vec(capabilities$kex_algorithms,",");
+    c$hassh$seastc = join_string_vec(capabilities$encryption_algorithms$server_to_client,",");
+    c$hassh$smastc = join_string_vec(capabilities$mac_algorithms$server_to_client,",");
+    c$hassh$scastc = join_string_vec(capabilities$compression_algorithms$server_to_client,",");
+    c$hassh$sshka  = join_string_vec(capabilities$server_host_key_algorithms,","); # The Host key algorithm set may be useful information by itself but is not included in the hasshServer.
+    #c$hassh$slstc  = join_string_vec(capabilities$languages$server_to_client,","); # The Languages field may be useful information by itself but is not included in the hasshServer.
+    c$hassh$hasshServerAlgorithms = string_cat(c$hassh$skex,";",c$hassh$seastc,";",c$hassh$smastc,";",c$hassh$scastc); # Contatenate the four selected lists of algorithms (Key,Enc,Message,Compression) to build the Server hash
+    c$hassh$hasshServer = md5_hash(c$hassh$hasshServerAlgorithms);
+}
+
+# Event #
+event ssh_capabilities(c: connection, cookie: string, capabilities: SSH::Capabilities) {
+    if ( !c?$ssh ) {return;}
+    c$hassh = HASSHStorage();
+    
+    # Prior to 2.6.0 Zeek has a bug which it reverses the Client/server flag.
+    # See https://github.com/zeek/zeek/pull/191
+    # The "if" statements here do a version check to account for this bug in versions older than 2.6.0
+    
+    if ((Version::info$version_number < 20600 && capabilities$is_server == T) || (Version::info$version_number >= 20600 && capabilities$is_server == F) ) {
+        get_hassh(c, capabilities);
+        c$ssh$hasshVersion = c$hassh$hasshVersion;
+        c$ssh$hassh  = c$hassh$hassh;
+        
+        # ===> Log Client variables <=== #
+        # Comment out any fields that are not required to be logged in their raw form to ssh.log
+        #c$ssh$ckex   = c$hassh$ckex;
+        c$ssh$cshka  = c$hassh$cshka;
+        #c$ssh$ceacts = c$hassh$ceacts;
+        #c$ssh$cmacts = c$hassh$cmacts;
+        #c$ssh$ccacts = c$hassh$ccacts;
+        #c$ssh$clcts  = c$hassh$clcts;
+        c$ssh$hasshAlgorithms = c$hassh$hasshAlgorithms;
+    }
+    if ( (Version::info$version_number < 20600 && capabilities$is_server == F) || (Version::info$version_number >= 20600 && capabilities$is_server == T) ) {
+        get_hasshServer(c, capabilities);
+        c$ssh$hasshVersion = c$hassh$hasshVersion;
+        c$ssh$hasshServer = c$hassh$hasshServer;
+        
+        # ===> Log Server variables <=== #
+        # Comment out any fields that are not required to be logged in their raw form to ssh.log
+        #c$ssh$skex   = c$hassh$skex;
+        c$ssh$sshka  = c$hassh$sshka;
+        #c$ssh$seastc = c$hassh$seastc;
+        #c$ssh$smastc = c$hassh$smastc;
+        #c$ssh$scastc = c$hassh$scastc;
+        #c$ssh$slstc  = c$hassh$clcts;
+        c$ssh$hasshServerAlgorithms = c$hassh$hasshServerAlgorithms;
+    }
+}

--- a/scripts/site/ja3/README.md
+++ b/scripts/site/ja3/README.md
@@ -1,0 +1,52 @@
+## Features
+- **ja3.zeek** will add the field "ja3" to ssl.log.  
+  - It can also append fields used by JA3 to ssl.log
+
+- **intel_ja3.zeek** will add INTEL::JA3 to the Zeek Intel Framwork
+  - This will allow you to import JA3 fingerprints directly into your intel feed.
+  
+- **ja3s.zeek** will add the field "ja3s" to ssl.log, JA3 for the server hello.
+  - It can also append fields used by JA3S to ssl.log.
+
+- Tested on Zeek 3.0.0
+
+## Installation
+- If you're running Zeek >= 3.0.0 or a Zeek product like Corelight, you can install by using the Zeek Package Manager and this one simple command:
+```bash
+zkg install ja3
+```
+
+- For everyone else, download the files to zeek/share/zeek/site/ja3 and add this line to your local.zeek script:
+```bash
+@load ./ja3
+```
+
+## Configuration
+
+By default ja3.zeek will only append ja3 to the ssl.log. However, if you would like to log all aspects of the SSL Client Hello Packet, uncomment the following lines in ja3.zeek
+```bash
+#  ja3_version:  string &optional &log;
+#  ja3_ciphers:  string &optional &log;
+#  ja3_extensions: string &optional &log;
+#  ja3_ec:         string &optional &log;
+#  ja3_ec_fmt:     string &optional &log;
+```
+...
+```bash
+#c$ssl$ja3_version = cat(c$tlsfp$client_version);
+#c$ssl$ja3_ciphers = c$tlsfp$client_ciphers;
+#c$ssl$ja3_extensions = c$tlsfp$extensions;
+#c$ssl$ja3_ec = c$tlsfp$e_curves;
+#c$ssl$ja3_ec_fmt = c$tlsfp$ec_point_fmt;
+```
+The same changes can be made in ja3s.zeek as well.
+
+___  
+### JA3 Created by
+
+[John B. Althouse](mailto:jalthouse@salesforce.com)  
+[Jeff Atkinson](mailto:jatkinson@salesforce.com)  
+[Josh Atkins](mailto:j.atkins@salesforce.com)  
+
+Please send questions and comments to **[John B. Althouse](mailto:jalthouse@salesforce.com)**.
+

--- a/scripts/site/ja3/__load__.zeek
+++ b/scripts/site/ja3/__load__.zeek
@@ -1,0 +1,3 @@
+@load ./ja3.zeek
+@load ./intel_ja3.zeek
+@load ./ja3s.zeek

--- a/scripts/site/ja3/intel_ja3.zeek
+++ b/scripts/site/ja3/intel_ja3.zeek
@@ -1,0 +1,28 @@
+# This Zeek script adds JA3 to the Zeek Intel Framework as Intel::JA3
+#
+# Author: John B. Althouse (jalthouse@salesforce.com)
+#
+# Copyright (c) 2017, salesforce.com, inc.
+# All rights reserved.
+# Licensed under the BSD 3-Clause license. 
+# For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+
+module Intel;
+
+export {
+    redef enum Intel::Type += { Intel::JA3 };
+}
+
+export {
+    redef enum Intel::Where += { SSL::IN_JA3 };
+}
+
+@if ( Version::at_least("2.6") || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec)
+@else
+event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec)
+@endif
+	{
+	if ( c$ssl?$ja3 )
+	Intel::seen([$indicator=c$ssl$ja3, $indicator_type=Intel::JA3, $conn=c, $where=SSL::IN_JA3]);
+	}

--- a/scripts/site/ja3/ja3.zeek
+++ b/scripts/site/ja3/ja3.zeek
@@ -1,0 +1,153 @@
+# This Zeek script appends JA3 to ssl.log
+# Version 1.4 (January 2020)
+#
+# Authors: John B. Althouse (jalthouse@salesforce.com) & Jeff Atkinson (jatkinson@salesforce.com)
+#
+# Copyright (c) 2017, salesforce.com, inc.
+# All rights reserved.
+# Licensed under the BSD 3-Clause license. 
+# For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+
+module JA3;
+
+export {
+redef enum Log::ID += { LOG };
+}
+
+type TLSFPStorage: record {
+       client_version:  count &default=0 &log;
+       client_ciphers:  string &default="" &log;
+       extensions:      string &default="" &log;
+       e_curves:        string &default="" &log;
+       ec_point_fmt:    string &default="" &log;
+};
+
+redef record connection += {
+       tlsfp: TLSFPStorage &optional;
+};
+
+redef record SSL::Info += {
+  ja3:            string &optional &log;
+# LOG FIELD VALUES ##
+#  ja3_version:  string &optional &log;
+#  ja3_ciphers:  string &optional &log;
+#  ja3_extensions: string &optional &log;
+#  ja3_ec:         string &optional &log;
+#  ja3_ec_fmt:     string &optional &log;
+};
+
+# Google. https://tools.ietf.org/html/draft-davidben-tls-grease-01
+const grease: set[int] = {
+    2570,
+    6682,
+    10794,
+    14906,
+    19018,
+    23130,
+    27242,
+    31354,
+    35466,
+    39578,
+    43690,
+    47802,
+    51914,
+    56026,
+    60138,
+    64250
+};
+const sep = "-";
+event zeek_init() {
+    Log::create_stream(JA3::LOG,[$columns=TLSFPStorage, $path="tlsfp"]);
+}
+
+event ssl_extension(c: connection, is_orig: bool, code: count, val: string)
+{
+if ( ! c?$tlsfp )
+    c$tlsfp=TLSFPStorage();
+    if ( is_orig == T ) {
+        if ( code in grease ) {
+            next;
+        }
+        if ( c$tlsfp$extensions == "" ) {
+            c$tlsfp$extensions = cat(code);
+        }
+        else {
+            c$tlsfp$extensions = string_cat(c$tlsfp$extensions, sep,cat(code));
+        }
+    }
+}
+
+event ssl_extension_ec_point_formats(c: connection, is_orig: bool, point_formats: index_vec)
+{
+if ( !c?$tlsfp )
+    c$tlsfp=TLSFPStorage();
+    if ( is_orig == T ) {
+        for ( i in point_formats ) {
+            if ( point_formats[i] in grease ) {
+            next;
+            }
+            if ( c$tlsfp$ec_point_fmt == "" ) {
+            c$tlsfp$ec_point_fmt += cat(point_formats[i]);
+            }
+            else {
+            c$tlsfp$ec_point_fmt += string_cat(sep,cat(point_formats[i]));
+            }
+        }
+    }
+}
+
+event ssl_extension_elliptic_curves(c: connection, is_orig: bool, curves: index_vec)
+{
+    if ( !c?$tlsfp )
+    c$tlsfp=TLSFPStorage();
+    if ( is_orig == T  ) {
+        for ( i in curves ) {
+            if ( curves[i] in grease ) {
+            next;
+            }
+            if ( c$tlsfp$e_curves == "" ) {
+                c$tlsfp$e_curves += cat(curves[i]);
+            }
+            else {
+                c$tlsfp$e_curves += string_cat(sep,cat(curves[i]));
+            }
+        }
+    }
+}
+
+@if ( ( Version::number >= 20600 ) || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) &priority=1
+@else
+event ssl_client_hello(c: connection, version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec) &priority=1
+@endif
+{
+    if ( !c?$tlsfp )
+    c$tlsfp=TLSFPStorage();
+    c$tlsfp$client_version = version;
+    for ( i in ciphers ) {
+        if ( ciphers[i] in grease ) {
+            next;
+        }
+        if ( c$tlsfp$client_ciphers == "" ) { 
+            c$tlsfp$client_ciphers += cat(ciphers[i]);
+        }
+        else {
+            c$tlsfp$client_ciphers += string_cat(sep,cat(ciphers[i]));
+        }
+    }
+    local sep2 = ",";
+    local ja3_string = string_cat(cat(c$tlsfp$client_version),sep2,c$tlsfp$client_ciphers,sep2,c$tlsfp$extensions,sep2,c$tlsfp$e_curves,sep2,c$tlsfp$ec_point_fmt);
+    local tlsfp_1 = md5_hash(ja3_string);
+    c$ssl$ja3 = tlsfp_1;
+
+# LOG FIELD VALUES ##
+#c$ssl$ja3_version = cat(c$tlsfp$client_version);
+#c$ssl$ja3_ciphers = c$tlsfp$client_ciphers;
+#c$ssl$ja3_extensions = c$tlsfp$extensions;
+#c$ssl$ja3_ec = c$tlsfp$e_curves;
+#c$ssl$ja3_ec_fmt = c$tlsfp$ec_point_fmt;
+#
+# FOR DEBUGGING ##
+#print "JA3: "+tlsfp_1+" Fingerprint String: "+ja3_string;
+
+}

--- a/scripts/site/ja3/ja3s.zeek
+++ b/scripts/site/ja3/ja3s.zeek
@@ -1,0 +1,82 @@
+# This Zeek script appends JA3S (JA3 Server) to ssl.log
+# Version 1.1 (January 2020)
+# This builds a fingerprint for the SSL Server Hello packet based on SSL/TLS version, cipher picked, and extensions used. 
+# Designed to be used in conjunction with JA3 to fingerprint SSL communication between clients and servers.
+#
+# Authors: John B. Althouse (jalthouse@salesforce.com) Jeff Atkinson (jatkinson@salesforce.com)
+# Copyright (c) 2018, salesforce.com, inc.
+# All rights reserved.
+# Licensed under the BSD 3-Clause license. 
+# For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+#
+
+
+
+module JA3_Server;
+
+export {
+redef enum Log::ID += { LOG };
+}
+
+type JA3Sstorage: record {
+       server_version:      count &default=0 &log;
+       server_cipher:      count &default=0 &log;
+       server_extensions:   string &default="" &log;
+};
+
+redef record connection += {
+       ja3sfp: JA3Sstorage &optional;
+};
+
+redef record SSL::Info += {
+  ja3s:            string &optional &log;
+# LOG FIELD VALUES #
+#  ja3s_version:  string &optional &log;
+#  ja3s_cipher:  string &optional &log;
+#  ja3s_extensions: string &optional &log;
+};
+
+
+const sep = "-";
+event zeek_init() {
+    Log::create_stream(JA3_Server::LOG,[$columns=JA3Sstorage, $path="ja3sfp"]);
+}
+
+event ssl_extension(c: connection, is_orig: bool, code: count, val: string)
+{
+if ( ! c?$ja3sfp )
+    c$ja3sfp=JA3Sstorage();
+    if ( is_orig == F ) { 
+        if ( c$ja3sfp$server_extensions == "" ) {
+            c$ja3sfp$server_extensions = cat(code);
+        }
+        else {
+            c$ja3sfp$server_extensions = string_cat(c$ja3sfp$server_extensions, sep,cat(code));
+        }
+    }
+}
+
+@if ( ( Version::number >= 20600 ) || ( Version::number == 20500 && Version::info$commit >= 944 ) )
+event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@else
+event ssl_server_hello(c: connection, version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) &priority=1
+@endif
+{
+    if ( !c?$ja3sfp )
+    c$ja3sfp=JA3Sstorage();
+    c$ja3sfp$server_version = version;
+    c$ja3sfp$server_cipher = cipher;
+    local sep2 = ",";
+    local ja3s_string = string_cat(cat(c$ja3sfp$server_version),sep2,cat(c$ja3sfp$server_cipher),sep2,c$ja3sfp$server_extensions);
+    local ja3sfp_1 = md5_hash(ja3s_string);
+    c$ssl$ja3s = ja3sfp_1;
+
+# LOG FIELD VALUES #
+#c$ssl$ja3s_version = cat(c$ja3sfp$server_version);
+#c$ssl$ja3s_cipher = cat(c$ja3sfp$server_cipher);
+#c$ssl$ja3s_extensions = c$ja3sfp$server_extensions;
+#
+# FOR DEBUGGING #
+#print "JA3S: "+ja3sfp_1+" Fingerprint String: "+ja3s_string;
+
+}

--- a/scripts/site/local.zeek
+++ b/scripts/site/local.zeek
@@ -100,3 +100,5 @@
 # Uncomment the following line to enable logging of link-layer addresses. Enabling
 # this adds the link-layer address for each connection endpoint to the conn.log file.
 # @load policy/protocols/conn/mac-logging
+@load ./ja3
+@load ./hassh


### PR DESCRIPTION
This PR adds the Zeek scripts for JA3 and HASSH to our Zeek artifact.

It includes a script `add-scripts.sh` that clones the repos from their original locations and copies the important bits into our repo at the right locations and adds the minimal commands to the `local.zeek` to make sure they're invoked when the Brim app is making Zeek logs out of pcaps.

I'd previously reported that HASSH was still "Bro"-ified and I was nervous that we'd have to use our own fork, but the maintainer did manage to merge the PR I'd put up. So we're now grabbing both JA3 and HASSH off-the-shelf from their proper upstream locations.

I've got a corresponding scratch Brim branch `add-ja3-hassh` that points to this artifact that I've used to confirm that everything is working as expected. Here's example events from running that branch with the additional fields showing up in the Zeek `ssl` and `ssh` events.

![image](https://user-images.githubusercontent.com/5934157/80320293-7556fc80-87ca-11ea-9f95-8b549b37a580.png)

![image](https://user-images.githubusercontent.com/5934157/80320317-961f5200-87ca-11ea-863b-37fa9f8b352e.png)

If folks like how this looks, two things that I know will still need to be addressed:

1. I'll need someone's help to revert commit `8697930` before merging. There's something wrong with how the tagging got set after the Zeek artifact was built and I'm too `git` dumb to figure out how to unravel it.

2. We'll need to figure out how to do this in Windows. Since these change are minimal I'd normally be willing to propose just making the same changes in @henridf's Cygwin-based repo to get us working ASAP. But I also know that @nwt's improved Windows build seems to be working, so maybe we're close to being able to do something on a united Zeek fork based on `v3.1.2`. I'll wait for input on that.

Closes #11.