### PR TITLE
Compile newer libpcap for Linux release

### DIFF
--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,8 +2,8 @@ name: Brim release
 
 on:
   push:
-    branches:
-      - newer-libpcap
+    tags:
+      - v*brim*
 
 jobs:
   release:

--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,8 +2,8 @@ name: Brim release
 
 on:
   push:
-    tags:
-      - v*brim*
+    branches
+      - zeek-brim-newer-libpcap
 
 jobs:
   release:

--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -3,7 +3,7 @@ name: Brim release
 on:
   push:
     branches:
-      - zeek-brim-newer-libpcap
+      - newer-libpcap
 
 jobs:
   release:

--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,7 +2,7 @@ name: Brim release
 
 on:
   push:
-    branches
+    branches:
       - zeek-brim-newer-libpcap
 
 jobs:

--- a/brim/release
+++ b/brim/release
@@ -9,13 +9,25 @@ case $(uname -s) in
     Linux)
         goos=linux
         logical_cpus=$(nproc)
-        sudo apt-get -y install bison flex libpcap-dev libssl-dev
+        sudo apt-get -y install bison flex libssl-dev
         ;;
     *)
         echo "unknown OS" >&2
         exit 1
         ;;
 esac
+
+# Compile a recent libpcap, since the one we'd get via apt-get is old and
+# hits https://github.com/brimsec/zeek/issues/17.
+(
+    cd $(mktemp -d)
+    wget https://github.com/the-tcpdump-group/libpcap/archive/libpcap-1.9.1.tar.gz
+    tar xzvf libpcap-1.9.1.tar.gz
+    cd libpcap-libpcap-1.9.1
+    ./configure
+    make
+    make install
+)
 
 git submodule update --init --recursive
 ./configure \

--- a/brim/release
+++ b/brim/release
@@ -10,24 +10,24 @@ case $(uname -s) in
         goos=linux
         logical_cpus=$(nproc)
         sudo apt-get -y install bison flex libssl-dev
+
+        # Compile a recent libpcap, since the one we'd get via apt-get is old
+        # and hits https://github.com/brimsec/zeek/issues/17.
+        (
+            cd $(mktemp -d)
+            wget https://github.com/the-tcpdump-group/libpcap/archive/libpcap-1.9.1.tar.gz
+            tar xzvf libpcap-1.9.1.tar.gz
+            cd libpcap-libpcap-1.9.1
+            ./configure
+            make
+            sudo make install
+        )
         ;;
     *)
         echo "unknown OS" >&2
         exit 1
         ;;
 esac
-
-# Compile a recent libpcap, since the one we'd get via apt-get is old and
-# hits https://github.com/brimsec/zeek/issues/17.
-(
-    cd $(mktemp -d)
-    wget https://github.com/the-tcpdump-group/libpcap/archive/libpcap-1.9.1.tar.gz
-    tar xzvf libpcap-1.9.1.tar.gz
-    cd libpcap-libpcap-1.9.1
-    ./configure
-    make
-    make install
-)
 
 git submodule update --init --recursive
 ./configure \


### PR DESCRIPTION
I'm not sure if this is the best way to go about it, but with the changes in this PR I've created a Zeek artifact that uses a newer libpcap and successfully processes pcapng files whereas the prior artifact did not.

```
# old-zeek/zeek/zeek -C -r hello.pcapng local
fatal error: problem with trace file hello.pcapng (invalid interface capture length 524288, bigger than maximum of 262144)

# new-zeek/zeek/zeek -C -r hello.pcapng local
WARNING: No Site::local_nets have been defined.  It's usually a good idea to define your local networks.
phil@phil-linux:~$ ls -l *.log
-rw-rw-r-- 1 phil phil   276 Apr 27 00:17 capture_loss.log
-rw-rw-r-- 1 phil phil   617 Apr 27 00:17 conn.log
-rw-rw-r-- 1 phil phil   783 Apr 27 00:17 files.log
-rw-rw-r-- 1 phil phil   881 Apr 27 00:17 http.log
-rw-rw-r-- 1 phil phil 31170 Apr 27 00:17 loaded_scripts.log
-rw-rw-r-- 1 phil phil   254 Apr 27 00:17 packet_filter.log
-rw-rw-r-- 1 phil phil   706 Apr 27 00:17 stats.log
```

Closes #17 