### PR TITLE
Add Zeek scripts for JA3 and HASSH (via zkg) (NOT YET FOR MERGE!)

### DIFF
--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,8 +2,8 @@ name: Brim release
 
 on:
   push:
-    branches:
-      - zeek-brim-ja3-hassh-via-zkg
+    tags:
+      - v*brim*
 
 jobs:
   release:

--- a/.github/workflows/brim-release.yml
+++ b/.github/workflows/brim-release.yml
@@ -2,8 +2,8 @@ name: Brim release
 
 on:
   push:
-    tags:
-      - v*brim*
+    branches:
+      - zeek-brim-ja3-hassh-via-zkg
 
 jobs:
   release:

--- a/brim/release
+++ b/brim/release
@@ -39,7 +39,7 @@ sudo make -C build/src -j $logical_cpus install/strip
 sudo pip install zkg==2.1.2
 sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/hassh --force --version cfa2315
 sudo bash -c 'echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek'
-sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/ja3 --foce --version 133f2a1
+sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/ja3 --force --version 133f2a1
 sudo bash -c 'echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek'
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek

--- a/brim/release
+++ b/brim/release
@@ -37,10 +37,10 @@ git submodule update --init --recursive
 	--enable-static-broker --osx-min-version=10.10
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
-export PATH="/usr/local/zeek/bin:$PATH"
-zkg autoconfig
-zkg install https://github.com/salesforce/hassh --force --version cfa2315
-zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1
+zkg install https://github.com/salesforce/hassh --force --version cfa2315 --config brim/zkg-config
+echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
+zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1 --config zkg-config
+echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek
 for d in base policy site; do

--- a/brim/release
+++ b/brim/release
@@ -29,7 +29,6 @@ case $(uname -s) in
         ;;
 esac
 
-sudo pip install zkg==2.1.2
 git submodule update --init --recursive
 ./configure \
 	--binary-package --disable-auxtools --disable-broker-tests \
@@ -37,6 +36,7 @@ git submodule update --init --recursive
 	--enable-static-broker --osx-min-version=10.10
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
+sudo pip install zkg==2.1.2
 zkg install https://github.com/salesforce/hassh --force --version cfa2315 --config brim/zkg-config
 echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
 zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1 --config zkg-config

--- a/brim/release
+++ b/brim/release
@@ -38,9 +38,9 @@ sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
 sudo pip install zkg==2.1.2
 sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/hassh --force --version cfa2315
-sudo echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
+sudo bash -c 'echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek'
 sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/ja3 --foce --version 133f2a1
-sudo echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek
+sudo bash -c 'echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek'
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek
 for d in base policy site; do

--- a/brim/release
+++ b/brim/release
@@ -36,11 +36,21 @@ git submodule update --init --recursive
 	--enable-static-broker --osx-min-version=10.10
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
+
+# Add additional community Zeek scripts
 sudo pip install zkg==2.1.2
-sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/hassh --force --version cfa2315
-sudo bash -c 'echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek'
-sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/ja3 --force --version 133f2a1
-sudo bash -c 'echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek'
+declare -a ADDED_ZSCRIPTS=(
+    'https://github.com/salesforce/hassh#cfa2315'
+    'https://github.com/salesforce/ja3#133f2a1'
+)
+for ZSCRIPT in "${ADDED_ZSCRIPTS[@]}"; do
+    REPO=$(echo "$ZSCRIPT" | cut -f1 -d#)
+    NAME=$(echo "$ZSCRIPT" | sed 's/^.*\///' | sed 's/#.*$//')
+    COMMIT=$(echo "$ZSCRIPT" | cut -f2 -d#)
+    sudo zkg --configfile brim/zkg-config install "$REPO" --force --version "$COMMIT"
+    sudo bash -c "echo \"@load ./$NAME\" >> /usr/local/zeek/share/zeek/site/local.zeek"
+done
+
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek
 for d in base policy site; do

--- a/brim/release
+++ b/brim/release
@@ -48,7 +48,7 @@ for ZSCRIPT in "${ADDED_ZSCRIPTS[@]}"; do
     NAME=$(echo "$ZSCRIPT" | sed 's/^.*\///' | sed 's/#.*$//')
     COMMIT=$(echo "$ZSCRIPT" | cut -f2 -d#)
     sudo zkg --configfile brim/zkg-config install "$REPO" --force --version "$COMMIT"
-    sudo bash -c "echo \"@load ./$NAME\" >> /usr/local/zeek/share/zeek/site/local.zeek"
+    sudo bash -c "echo \"@load ./$NAME\ # $ZSCRIPT" >> /usr/local/zeek/share/zeek/site/local.zeek"
 done
 
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin

--- a/brim/release
+++ b/brim/release
@@ -37,10 +37,10 @@ git submodule update --init --recursive
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
 sudo pip install zkg==2.1.2
-zkg install https://github.com/salesforce/hassh --force --version cfa2315 --config brim/zkg-config
-echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
-zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1 --config zkg-config
-echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek
+sudo zkg install https://github.com/salesforce/hassh --force --version cfa2315 --config brim/zkg-config
+sudo echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
+sudo zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1 --config zkg-config
+sudo echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek
 for d in base policy site; do

--- a/brim/release
+++ b/brim/release
@@ -29,6 +29,7 @@ case $(uname -s) in
         ;;
 esac
 
+sudo pip install zkg==2.1.2
 git submodule update --init --recursive
 ./configure \
 	--binary-package --disable-auxtools --disable-broker-tests \
@@ -36,6 +37,10 @@ git submodule update --init --recursive
 	--enable-static-broker --osx-min-version=10.10
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
+export PATH="/usr/local/zeek/bin:$PATH"
+zkg autoconfig
+zkg install https://github.com/salesforce/hassh --force --version cfa2315
+zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek
 for d in base policy site; do

--- a/brim/release
+++ b/brim/release
@@ -48,7 +48,7 @@ for ZSCRIPT in "${ADDED_ZSCRIPTS[@]}"; do
     NAME=$(echo "$ZSCRIPT" | sed 's/^.*\///' | sed 's/#.*$//')
     COMMIT=$(echo "$ZSCRIPT" | cut -f2 -d#)
     sudo zkg --configfile brim/zkg-config install "$REPO" --force --version "$COMMIT"
-    sudo bash -c "echo \"@load ./$NAME\ # $ZSCRIPT" >> /usr/local/zeek/share/zeek/site/local.zeek"
+    sudo bash -c "echo \"@load ./$NAME # $ZSCRIPT\" >> /usr/local/zeek/share/zeek/site/local.zeek"
 done
 
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin

--- a/brim/release
+++ b/brim/release
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 case $(uname -s) in
     Darwin)

--- a/brim/release
+++ b/brim/release
@@ -37,9 +37,9 @@ git submodule update --init --recursive
 sudo make -C build/scripts -j $logical_cpus install/strip
 sudo make -C build/src -j $logical_cpus install/strip
 sudo pip install zkg==2.1.2
-sudo zkg install https://github.com/salesforce/hassh --force --version cfa2315 --config brim/zkg-config
+sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/hassh --force --version cfa2315
 sudo echo "@load ./hassh" >> /usr/local/zeek/share/zeek/local.zeek
-sudo zkg install https://github.com/salesforce/ja3 --foce --version 133f2a1 --config zkg-config
+sudo zkg --configfile brim/zkg-config install https://github.com/salesforce/ja3 --foce --version 133f2a1
 sudo echo "@load ./ja3" >> /usr/local/zeek/share/zeek/local.zeek
 mkdir -p zeek/bin && cp /usr/local/zeek/bin/zeek zeek/bin
 mkdir -p zeek/share/zeek

--- a/brim/zkg-config
+++ b/brim/zkg-config
@@ -2,6 +2,6 @@
 zeek = https://github.com/zeek/packages
 
 [paths]
-state_dir = /root/.zkg
+state_dir = /tmp/.zkg
 script_dir = /usr/local/zeek/share/zeek/site
 plugin_dir = /usr/local/zeek/lib/zeek/plugins

--- a/brim/zkg-config
+++ b/brim/zkg-config
@@ -1,0 +1,7 @@
+[sources]
+zeek = https://github.com/zeek/packages
+
+[paths]
+state_dir = /root/.zkg
+script_dir = /usr/local/zeek/share/zeek/site
+plugin_dir = /usr/local/zeek/lib/zeek/plugins


### PR DESCRIPTION
As suggested in the review comments of https://github.com/brimsec/zeek/pull/18, in this PR we install the Zeek scripts for JA3 and HASSH via [Zeek Package Manager](https://docs.zeek.org/projects/package-manager/en/stable/). For each script, the URL and commit hash of what gets installed is included as a comment in `local.zeek` alongside the `@load` command that invokes it.

If this is approved, I'll push one more commit to undo the Actions workflow before I merge.