### PR TITLE
Windows: fix calc_next_rotate()

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1900,11 +1900,7 @@ double parse_rotate_base_time(const char* rotate_base_time)
 		{
 		struct tm t;
 		if ( ! strptime(rotate_base_time, "%H:%M", &t) )
-			{
 			reporter->Warning("calc_next_rotate(): can't parse rotation base time");
-			base = 86400;
-			}
-		
 		else
 			base = t.tm_min * 60 + t.tm_hour * 60 * 60;
 		}

--- a/src/windows/CMakeLists.txt
+++ b/src/windows/CMakeLists.txt
@@ -10,6 +10,7 @@ bro_add_subdir_library(windows
     regex.c
     stdio.c
     stdlib.c
+    strptime.c
     sys.resource.c
     time.c
     unistd.c

--- a/src/windows/strptime.c
+++ b/src/windows/strptime.c
@@ -1,0 +1,402 @@
+// Copied from https://github.com/openssh/openssh-portable/blob/aa74f6754aa3696cf15abb3f27b00a7274e062dd/openbsd-compat/strptime.c.
+
+/*	$OpenBSD: strptime.c,v 1.12 2008/06/26 05:42:05 ray Exp $ */
+/*	$NetBSD: strptime.c,v 1.12 1998/01/20 21:39:40 mycroft Exp $	*/
+
+/*-
+ * Copyright (c) 1997, 1998 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code was contributed to The NetBSD Foundation by Klaus Klein.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/time/strptime.c */
+
+// #include "includes.h"
+
+#ifndef HAVE_STRPTIME
+
+#define TM_YEAR_BASE 1900	/* from tzfile.h */
+
+#include <ctype.h>
+#include <locale.h>
+#include <string.h>
+#include <time.h>
+
+/* #define	_ctloc(x)		(_CurrentTimeLocale->x) */
+
+/*
+ * We do not implement alternate representations. However, we always
+ * check whether a given modifier is allowed for a certain conversion.
+ */
+#define _ALT_E			0x01
+#define _ALT_O			0x02
+#define	_LEGAL_ALT(x)		{ if (alt_format & ~(x)) return (0); }
+
+
+static	int _conv_num(const unsigned char **, int *, int, int);
+static	char *_strptime(const char *, const char *, struct tm *, int);
+
+
+char *
+strptime(const char *buf, const char *fmt, struct tm *tm)
+{
+	return(_strptime(buf, fmt, tm, 1));
+}
+
+static char *
+_strptime(const char *buf, const char *fmt, struct tm *tm, int initialize)
+{
+	unsigned char c;
+	const unsigned char *bp;
+	size_t len;
+	int alt_format, i;
+	static int century, relyear;
+
+	if (initialize) {
+		century = TM_YEAR_BASE;
+		relyear = -1;
+	}
+
+	bp = (unsigned char *)buf;
+	while ((c = *fmt) != '\0') {
+		/* Clear `alternate' modifier prior to new conversion. */
+		alt_format = 0;
+
+		/* Eat up white-space. */
+		if (isspace(c)) {
+			while (isspace(*bp))
+				bp++;
+
+			fmt++;
+			continue;
+		}
+				
+		if ((c = *fmt++) != '%')
+			goto literal;
+
+
+again:		switch (c = *fmt++) {
+		case '%':	/* "%%" is converted to "%". */
+literal:
+		if (c != *bp++)
+			return (NULL);
+
+		break;
+
+		/*
+		 * "Alternative" modifiers. Just set the appropriate flag
+		 * and start over again.
+		 */
+		case 'E':	/* "%E?" alternative conversion modifier. */
+			_LEGAL_ALT(0);
+			alt_format |= _ALT_E;
+			goto again;
+
+		case 'O':	/* "%O?" alternative conversion modifier. */
+			_LEGAL_ALT(0);
+			alt_format |= _ALT_O;
+			goto again;
+			
+		/*
+		 * "Complex" conversion rules, implemented through recursion.
+		 */
+#if 0
+		case 'c':	/* Date and time, using the locale's format. */
+			_LEGAL_ALT(_ALT_E);
+			if (!(bp = _strptime(bp, _ctloc(d_t_fmt), tm, 0)))
+				return (NULL);
+			break;
+#endif
+		case 'D':	/* The date as "%m/%d/%y". */
+			_LEGAL_ALT(0);
+			if (!(bp = _strptime(bp, "%m/%d/%y", tm, 0)))
+				return (NULL);
+			break;
+	
+		case 'R':	/* The time as "%H:%M". */
+			_LEGAL_ALT(0);
+			if (!(bp = _strptime(bp, "%H:%M", tm, 0)))
+				return (NULL);
+			break;
+
+		case 'r':	/* The time as "%I:%M:%S %p". */
+			_LEGAL_ALT(0);
+			if (!(bp = _strptime(bp, "%I:%M:%S %p", tm, 0)))
+				return (NULL);
+			break;
+
+		case 'T':	/* The time as "%H:%M:%S". */
+			_LEGAL_ALT(0);
+			if (!(bp = _strptime(bp, "%H:%M:%S", tm, 0)))
+				return (NULL);
+			break;
+#if 0
+		case 'X':	/* The time, using the locale's format. */
+			_LEGAL_ALT(_ALT_E);
+			if (!(bp = _strptime(bp, _ctloc(t_fmt), tm, 0)))
+				return (NULL);
+			break;
+
+		case 'x':	/* The date, using the locale's format. */
+			_LEGAL_ALT(_ALT_E);
+			if (!(bp = _strptime(bp, _ctloc(d_fmt), tm, 0)))
+				return (NULL);
+			break;
+#endif
+		/*
+		 * "Elementary" conversion rules.
+		 */
+#if 0
+		case 'A':	/* The day of week, using the locale's form. */
+		case 'a':
+			_LEGAL_ALT(0);
+			for (i = 0; i < 7; i++) {
+				/* Full name. */
+				len = strlen(_ctloc(day[i]));
+				if (strncasecmp(_ctloc(day[i]), bp, len) == 0)
+					break;
+
+				/* Abbreviated name. */
+				len = strlen(_ctloc(abday[i]));
+				if (strncasecmp(_ctloc(abday[i]), bp, len) == 0)
+					break;
+			}
+
+			/* Nothing matched. */
+			if (i == 7)
+				return (NULL);
+
+			tm->tm_wday = i;
+			bp += len;
+			break;
+
+		case 'B':	/* The month, using the locale's form. */
+		case 'b':
+		case 'h':
+			_LEGAL_ALT(0);
+			for (i = 0; i < 12; i++) {
+				/* Full name. */
+				len = strlen(_ctloc(mon[i]));
+				if (strncasecmp(_ctloc(mon[i]), bp, len) == 0)
+					break;
+
+				/* Abbreviated name. */
+				len = strlen(_ctloc(abmon[i]));
+				if (strncasecmp(_ctloc(abmon[i]), bp, len) == 0)
+					break;
+			}
+
+			/* Nothing matched. */
+			if (i == 12)
+				return (NULL);
+
+			tm->tm_mon = i;
+			bp += len;
+			break;
+#endif
+
+		case 'C':	/* The century number. */
+			_LEGAL_ALT(_ALT_E);
+			if (!(_conv_num(&bp, &i, 0, 99)))
+				return (NULL);
+
+			century = i * 100;
+			break;
+
+		case 'd':	/* The day of month. */
+		case 'e':
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_mday, 1, 31)))
+				return (NULL);
+			break;
+
+		case 'k':	/* The hour (24-hour clock representation). */
+			_LEGAL_ALT(0);
+			/* FALLTHROUGH */
+		case 'H':
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_hour, 0, 23)))
+				return (NULL);
+			break;
+
+		case 'l':	/* The hour (12-hour clock representation). */
+			_LEGAL_ALT(0);
+			/* FALLTHROUGH */
+		case 'I':
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_hour, 1, 12)))
+				return (NULL);
+			break;
+
+		case 'j':	/* The day of year. */
+			_LEGAL_ALT(0);
+			if (!(_conv_num(&bp, &tm->tm_yday, 1, 366)))
+				return (NULL);
+			tm->tm_yday--;
+			break;
+
+		case 'M':	/* The minute. */
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_min, 0, 59)))
+				return (NULL);
+			break;
+
+		case 'm':	/* The month. */
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_mon, 1, 12)))
+				return (NULL);
+			tm->tm_mon--;
+			break;
+
+#if 0
+		case 'p':	/* The locale's equivalent of AM/PM. */
+			_LEGAL_ALT(0);
+			/* AM? */
+			len = strlen(_ctloc(am_pm[0]));
+			if (strncasecmp(_ctloc(am_pm[0]), bp, len) == 0) {
+				if (tm->tm_hour > 12)	/* i.e., 13:00 AM ?! */
+					return (NULL);
+				else if (tm->tm_hour == 12)
+					tm->tm_hour = 0;
+
+				bp += len;
+				break;
+			}
+			/* PM? */
+			len = strlen(_ctloc(am_pm[1]));
+			if (strncasecmp(_ctloc(am_pm[1]), bp, len) == 0) {
+				if (tm->tm_hour > 12)	/* i.e., 13:00 PM ?! */
+					return (NULL);
+				else if (tm->tm_hour < 12)
+					tm->tm_hour += 12;
+
+				bp += len;
+				break;
+			}
+
+			/* Nothing matched. */
+			return (NULL);
+#endif
+		case 'S':	/* The seconds. */
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_sec, 0, 61)))
+				return (NULL);
+			break;
+
+		case 'U':	/* The week of year, beginning on sunday. */
+		case 'W':	/* The week of year, beginning on monday. */
+			_LEGAL_ALT(_ALT_O);
+			/*
+			 * XXX This is bogus, as we can not assume any valid
+			 * information present in the tm structure at this
+			 * point to calculate a real value, so just check the
+			 * range for now.
+			 */
+			 if (!(_conv_num(&bp, &i, 0, 53)))
+				return (NULL);
+			 break;
+
+		case 'w':	/* The day of week, beginning on sunday. */
+			_LEGAL_ALT(_ALT_O);
+			if (!(_conv_num(&bp, &tm->tm_wday, 0, 6)))
+				return (NULL);
+			break;
+
+		case 'Y':	/* The year. */
+			_LEGAL_ALT(_ALT_E);
+			if (!(_conv_num(&bp, &i, 0, 9999)))
+				return (NULL);
+
+			relyear = -1;
+			tm->tm_year = i - TM_YEAR_BASE;
+			break;
+
+		case 'y':	/* The year within the century (2 digits). */
+			_LEGAL_ALT(_ALT_E | _ALT_O);
+			if (!(_conv_num(&bp, &relyear, 0, 99)))
+				return (NULL);
+			break;
+
+		/*
+		 * Miscellaneous conversions.
+		 */
+		case 'n':	/* Any kind of white-space. */
+		case 't':
+			_LEGAL_ALT(0);
+			while (isspace(*bp))
+				bp++;
+			break;
+
+
+		default:	/* Unknown/unsupported conversion. */
+			return (NULL);
+		}
+
+
+	}
+
+	/*
+	 * We need to evaluate the two digit year spec (%y)
+	 * last as we can get a century spec (%C) at any time.
+	 */
+	if (relyear != -1) {
+		if (century == TM_YEAR_BASE) {
+			if (relyear <= 68)
+				tm->tm_year = relyear + 2000 - TM_YEAR_BASE;
+			else
+				tm->tm_year = relyear + 1900 - TM_YEAR_BASE;
+		} else {
+			tm->tm_year = relyear + century - TM_YEAR_BASE;
+		}
+	}
+
+	return ((char *)bp);
+}
+
+
+static int
+_conv_num(const unsigned char **buf, int *dest, int llim, int ulim)
+{
+	int result = 0;
+	int rulim = ulim;
+
+	if (**buf < '0' || **buf > '9')
+		return (0);
+
+	/* we use rulim to break out of the loop when we run out of digits */
+	do {
+		result *= 10;
+		result += *(*buf)++ - '0';
+		rulim /= 10;
+	} while ((result * 10 <= ulim) && rulim && **buf >= '0' && **buf <= '9');
+
+	if (result < llim || result > ulim)
+		return (0);
+
+	*dest = result;
+	return (1);
+}
+
+#endif /* HAVE_STRPTIME */

--- a/src/windows/time.c
+++ b/src/windows/time.c
@@ -21,11 +21,6 @@ struct tm *localtime_r(const time_t *timer, struct tm *result)
 	return result;
 	}
 
-char* strptime(const char* s, const char* f, struct tm* tm)
-	{
-	return NULL;
-	}
-
 time_t timegm(struct tm *tm)
 	{
 	return _mkgmtime(tm);


### PR DESCRIPTION
This should fix #28.

I tried to avoid adding strptime.c by doing something like https://stackoverflow.com/a/33542189, but it failed on "0:00" because libstdc++'s std::get_time() requires two input characters for %H.