### PR TITLE
Install Zeek package for geoip-conn to enable geolocation data

### DIFF
--- a/.github/workflows/brim.yml
+++ b/.github/workflows/brim.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - geolocation
     tags:
       - v*brim*
 

--- a/.github/workflows/brim.yml
+++ b/.github/workflows/brim.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - geolocation
     tags:
       - v*brim*
 

--- a/brim/release
+++ b/brim/release
@@ -32,7 +32,7 @@ case $(uname) in
         pacman -S --needed --noconfirm \
             bison flex mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc \
             mingw-w64-x86_64-ninja mingw-w64-x86_64-openssl python-pip zip \
-            mingw-w64-libmaxminddb
+            mingw-w64-x86_64-libmaxminddb
         install_libpcap /mingw64
         # Switch to real symlinks.
         git config --replace-all core.symlinks true

--- a/brim/release
+++ b/brim/release
@@ -14,11 +14,12 @@ install_libpcap() {
 case $(uname) in
     Darwin)
         sudo=sudo
-        brew install bison ninja openssl
+        brew install bison ninja openssl libmaxminddb
         ;;
     Linux)
         sudo=sudo
-        sudo apt-get -y install bison flex libssl-dev ninja-build
+        sudo apt-get -y install bison flex libssl-dev ninja-build \
+            libmaxminddb-dev
         # Compile a recent libpcap since the one we'd get via apt-get is
         # old and hits https://github.com/brimsec/zeek/issues/17.
         install_libpcap /
@@ -30,7 +31,8 @@ case $(uname) in
         go build -o brim/zeekrunner.exe brim/zeekrunner.go
         pacman -S --needed --noconfirm \
             bison flex mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc \
-            mingw-w64-x86_64-ninja mingw-w64-x86_64-openssl python-pip zip
+            mingw-w64-x86_64-ninja mingw-w64-x86_64-openssl python-pip zip \
+            mingw-w64-libmaxminddb
         install_libpcap /mingw64
         # Switch to real symlinks.
         git config --replace-all core.symlinks true
@@ -61,9 +63,11 @@ if [ "$OS" = Windows_NT ]; then
     PATH=$PWD/build:$PATH zkg autoconfig
     mkdir -p /usr/local/zeek/share/zeek/site/packages/hassh
     mkdir -p /usr/local/zeek/share/zeek/site/packages/ja3
+    mkdir -p /usr/local/zeek/share/zeek/site/packages/geoip-conn
 fi
 $sudo zkg install --force hassh --version cfa2315257eaa972e86f7fcd694712e0d32762ff
 $sudo zkg install --force ja3 --version 133f2a128b873f9c40e4e65c2b9dc372a801cf24
+$sudo zkg install --force https://github.com/philrz/geoip-conn
 
 mkdir -p zeek/bin zeek/share/zeek
 cp brim/zeekrunner$exe zeek

--- a/brim/release
+++ b/brim/release
@@ -67,7 +67,7 @@ if [ "$OS" = Windows_NT ]; then
 fi
 $sudo zkg install --force hassh --version cfa2315257eaa972e86f7fcd694712e0d32762ff
 $sudo zkg install --force ja3 --version 133f2a128b873f9c40e4e65c2b9dc372a801cf24
-$sudo zkg install --force https://github.com/philrz/geoip-conn
+$sudo zkg install --force https://github.com/brimsec/geoip-conn --version 3d6ecdfd7d7b942ac374963d12f4945d514ed3bd
 
 mkdir -p zeek/bin zeek/share/zeek
 cp brim/zeekrunner$exe zeek


### PR DESCRIPTION
I've discussed this one on Slack with @alfred-landrum and @henridf . I've already tested a Zeek artifact with the Brim app on macOS/Linux/Windows that had a previous version of this plugin, so I know the approach of adding libmaxminddb support & the package install does the trick. Here's an example of a `conn` record with the geolocation data populated:

```
{
  "_path": "conn",
  "conn_state": "S0",
  "duration": "2.999489",
  "geo": {
    "orig": {
      "city": null,
      "country_code": null,
      "latitude": null,
      "longitude": null,
      "region": null
    },
    "resp": {
      "city": "Harare",
      "country_code": "ZW",
      "latitude": -17.815,
      "longitude": 31.0478,
      "region": "HA"
    }
  },
  "history": "S",
  "id": {
    "orig_h": "192.168.0.54",
    "orig_p": 53833,
    "resp_h": "197.211.219.130",
    "resp_p": 443
  },
  "local_orig": null,
  "local_resp": null,
  "missed_bytes": 0,
  "orig_bytes": 0,
  "orig_ip_bytes": 104,
  "orig_pkts": 2,
  "proto": "tcp",
  "resp_bytes": 0,
  "resp_ip_bytes": 0,
  "resp_pkts": 0,
  "service": null,
  "ts": "1427784089.665289",
  "tunnel_parents": null,
  "uid": "CMQzazABmKlDlJ27k"
}
```