### PR TITLE
Point to geoip-conn Zeek package that includes 2020-07-21 db update

### DIFF
--- a/brim/release
+++ b/brim/release
@@ -67,7 +67,7 @@ if [ "$OS" = Windows_NT ]; then
 fi
 $sudo zkg install --force hassh --version cfa2315257eaa972e86f7fcd694712e0d32762ff
 $sudo zkg install --force ja3 --version 133f2a128b873f9c40e4e65c2b9dc372a801cf24
-$sudo zkg install --force https://github.com/brimsec/geoip-conn --version 3d6ecdfd7d7b942ac374963d12f4945d514ed3bd
+$sudo zkg install --force geoip-conn --version 66f3905f8a410e6aa6a6e95dd9b07c3e4f4fc2ca
 
 mkdir -p zeek/bin zeek/share/zeek
 cp brim/zeekrunner$exe zeek


### PR DESCRIPTION
In preparation for creating a new Brim release, this PR points to the latest version of the [geoip-conn](https://github.com/brimsec/geoip-conn) Zeek package, which includes the MaxMind GeoLite2 db datestamped 2020-07-21.

While making this change, I've also simplified the `zkg install` line, which effectively adds a layer of redirection through https://github.com/zeek/packages/tree/master/brimsec. I've done this for consistency with how we install the other packages.