### PR TITLE
Update geoip-conn Zeek package to commit that includes 2020-10-06 db

### DIFF
--- a/brim/release
+++ b/brim/release
@@ -87,7 +87,7 @@ if [ "$OS" = Windows_NT ]; then
 fi
 $sudo zkg install --force hassh --version cfa2315257eaa972e86f7fcd694712e0d32762ff
 $sudo zkg install --force ja3 --version 133f2a128b873f9c40e4e65c2b9dc372a801cf24
-$sudo zkg install --force geoip-conn --version 73c8ab445112585195de9a3b2cd1140b68c367b4
+$sudo zkg install --force geoip-conn --version f8c66962d15a09052ab64a6413c1eadcb23e4ca2
 
 #
 # Create zip file.


### PR DESCRIPTION
The geolocation database just got updated, so with #42 having just merged, it's a fine opportunity to create a new Zeek artifact and see how it does with the Brim integration tests now that the logs will be Zeek v.3.2.1 style. Based on a Slack conversation with @nwt it sounds like a few things in the Zeek TSV output may have changed slightly from the way they were before, but I don't have a lot of experience in the degree to which the integration tests rely on very specific formatting of the Zeek events. I guess I'm about to find out.